### PR TITLE
Update Output.php - only for the Romanian version

### DIFF
--- a/include/tool/Output.php
+++ b/include/tool/Output.php
@@ -2003,7 +2003,7 @@ namespace gp\tool{
 			if( !isset($config['showgplink']) || $config['showgplink'] ){
 				if( self::is_front_page() ){
 					echo ' <span id="powered_by_link">';
-					echo 'Powered by <a href="'.CMS_DOMAIN.'" target="_blank">'.CMS_NAME.'</a>';
+					echo 'Propulsat de <a href="'.CMS_DOMAIN.'" target="_blank">'.CMS_NAME.'</a>';
 					echo '</span>';
 				}
 			}


### PR DESCRIPTION
only for the Romanian version: change to display "Propulsat de " instead of "Powered by " at line 2006
good for promotion typesetter in Romania ! keep link to Typesetter CMS in page footer in romanian language !
